### PR TITLE
Feat: implement modify

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/pydo/__init__.py
+++ b/pydo/__init__.py
@@ -37,7 +37,7 @@ def main():
 
     if args.subcommand == 'install':
         install(session, logging.getLogger('main'))
-    elif args.subcommand in ['add', 'modify', 'del', 'done']:
+    elif args.subcommand in ['add', 'mod', 'del', 'done']:
         task_manager = TaskManager(session)
 
         if args.subcommand == 'add':
@@ -45,7 +45,7 @@ def main():
             task_manager.add(
                 **attributes
             )
-        elif args.subcommand == 'modify':
+        elif args.subcommand == 'mod':
             attributes = task_manager._parse_arguments(args.modify_argument)
             task_manager.modify(
                 args.ulid,

--- a/pydo/__init__.py
+++ b/pydo/__init__.py
@@ -37,12 +37,18 @@ def main():
 
     if args.subcommand == 'install':
         install(session, logging.getLogger('main'))
-    elif args.subcommand in ['add', 'del', 'done']:
+    elif args.subcommand in ['add', 'modify', 'del', 'done']:
         task_manager = TaskManager(session)
 
         if args.subcommand == 'add':
             attributes = task_manager._parse_arguments(args.add_argument)
             task_manager.add(
+                **attributes
+            )
+        elif args.subcommand == 'modify':
+            attributes = task_manager._parse_arguments(args.modify_argument)
+            task_manager.modify(
+                args.ulid,
                 **attributes
             )
         elif args.subcommand == 'del':

--- a/pydo/cli.py
+++ b/pydo/cli.py
@@ -33,7 +33,7 @@ def load_parser():
         nargs=argparse.REMAINDER,
     )
 
-    modify_parser = subparser.add_parser('modify')
+    modify_parser = subparser.add_parser('mod')
     modify_parser.add_argument(
         "ulid",
         type=str,

--- a/pydo/cli.py
+++ b/pydo/cli.py
@@ -33,6 +33,20 @@ def load_parser():
         nargs=argparse.REMAINDER,
     )
 
+    modify_parser = subparser.add_parser('modify')
+    modify_parser.add_argument(
+        "ulid",
+        type=str,
+        help='Task ulid',
+    )
+    modify_parser.add_argument(
+        "modify_argument",
+        type=str,
+        help='Task modify arguments',
+        default=None,
+        nargs=argparse.REMAINDER,
+    )
+
     delete_parser = subparser.add_parser('del')
     delete_parser.add_argument(
         "ulid",

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -407,6 +407,31 @@ class TaskManager(TableManager):
         if commit_necessary:
             self.session.commit()
 
+    def _set_agile(
+        self,
+        task_attributes,
+        agile=None
+    ):
+        """
+        Method to set the agile attribute.
+
+        If the agile tag value isn't between the specified ones,
+        a `ValueError` will be raised.
+
+        Arguments:
+            task_attributes (dict): Dictionary with the attributes of the task.
+            agile (str): Task agile state.
+        """
+        if agile is not None and \
+                agile not in self.config.get('task.agile.states').split(', '):
+            raise ValueError(
+                'Agile state {} is not between the specified '
+                'by task.agile.states'.format(agile)
+            )
+
+        if agile is not None:
+            task_attributes['agile'] = agile
+
     def _set(
         self,
         id=None,
@@ -452,17 +477,7 @@ class TaskManager(TableManager):
             task_attributes['tags'] = []
 
         self._set_tags(task_attributes, tags)
-
-        # Test the task attributes are into the available choices
-        if agile is not None and \
-                agile not in self.config.get('task.agile.states').split(', '):
-            raise ValueError(
-                'Agile state {} is not between the specified '
-                'by task.agile.states'.format(agile)
-            )
-
-        if agile is not None:
-            task_attributes['agile'] = agile
+        self._set_agile(task_attributes, agile)
 
         for key, value in kwargs.items():
             task_attributes[key] = value

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -209,6 +209,10 @@ class TaskManager(TableManager):
             attributes.
         _get_fulid: Method to get the task's fulid if necessary.
         _set: Method to set the task's attributes and get its fulid.
+        _set_project: Method to set the project attribute.
+        _set_tags: Method to set the tags attribute.
+        _rm_tags: Method to delete tags from the Task attributes.
+        _set_agile: Method to set the agile attribute.
 
     Public attributes:
         fulid (fulid object): Fulid manager and generator object.

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -407,6 +407,24 @@ class TaskManager(TableManager):
         if commit_necessary:
             self.session.commit()
 
+    def _rm_tags(
+        self,
+        task_attributes,
+        tags_rm=[]
+    ):
+        """
+        Method to delete tags from the Task attributes.
+
+        Arguments:
+            task_attributes (dict): Dictionary with the attributes of the task.
+            tags_rm (list): List of tag ids to remove.
+        """
+        for tag_id in tags_rm:
+            tag = self.session.query(Tag).get(tag_id)
+            if tag is None:
+                raise ValueError("The tag doesn't exist")
+            task_attributes['tags'].remove(tag)
+
     def _set_agile(
         self,
         task_attributes,
@@ -467,12 +485,7 @@ class TaskManager(TableManager):
             task = self.session.query(Task).get(fulid)
             task_attributes['tags'] = task.tags
 
-            for tag_id in tags_rm:
-                tag = self.session.query(Tag).get(tag_id)
-                if tag is None:
-                    tag = Tag(id=tag_id, description='')
-                    self.session.add(tag)
-                task_attributes['tags'].remove(tag)
+            self._rm_tags(task_attributes, tags_rm)
 
         self._set_tags(task_attributes, tags)
         self._set_agile(task_attributes, agile)

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -384,7 +384,6 @@ class TaskManager(TableManager):
             if project is None:
                 project = Project(id=project_id, description='')
                 self.session.add(project)
-                self.session.commit()
             task_attributes['project'] = project
 
         # Define tags
@@ -399,7 +398,6 @@ class TaskManager(TableManager):
                 if tag is None:
                     tag = Tag(id=tag_id, description='')
                     self.session.add(tag)
-                    self.session.commit()
                 task_attributes['tags'].remove(tag)
         else:
             fulid = None
@@ -410,8 +408,9 @@ class TaskManager(TableManager):
             if tag is None:
                 tag = Tag(id=tag_id, description='')
                 self.session.add(tag)
-                self.session.commit()
             task_attributes['tags'].append(tag)
+
+        self.session.commit()
 
         # Test the task attributes are into the available choices
         if agile is not None and \

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -468,8 +468,8 @@ class TaskManager(TableManager):
         fulid, task_attributes = self._set(None,
                                            project_id,
                                            tags,
-                                           agile,
                                            None,
+                                           agile,
                                            title=title,
                                            state='open',
                                            **kwargs)

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -201,11 +201,14 @@ class TaskManager(TableManager):
 
     Internal methods:
         _add: Parent method to add table elements.
+        _update: Parent method to update table elements.
         _close: Closes a task.
         _parse_attribute: Parse a Taskwarrior like add argument into a task
             attribute.
         _parse_arguments: Parse a Taskwarrior like add query into task
             attributes.
+        _get_fulid: Method to get the task's fulid if necessary.
+        _set: Method to set the task's attributes and get its fulid.
 
     Public attributes:
         fulid (fulid object): Fulid manager and generator object.

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -359,11 +359,7 @@ class TaskManager(TableManager):
 
         return fulid
 
-    def _set_project(
-        self,
-        task_attributes,
-        project_id=None
-    ):
+    def _set_project(self, task_attributes, project_id=None):
         """
         Method to set the project attribute.
 
@@ -381,11 +377,7 @@ class TaskManager(TableManager):
                 self.session.commit()
             task_attributes['project'] = project
 
-    def _set_tags(
-        self,
-        task_attributes,
-        tags=[]
-    ):
+    def _set_tags(self, task_attributes, tags=[]):
         """
         Method to set the tags attribute.
 
@@ -411,11 +403,7 @@ class TaskManager(TableManager):
         if commit_necessary:
             self.session.commit()
 
-    def _rm_tags(
-        self,
-        task_attributes,
-        tags_rm=[]
-    ):
+    def _rm_tags(self, task_attributes, tags_rm=[]):
         """
         Method to delete tags from the Task attributes.
 
@@ -429,15 +417,11 @@ class TaskManager(TableManager):
                 raise ValueError("The tag doesn't exist")
             task_attributes['tags'].remove(tag)
 
-    def _set_agile(
-        self,
-        task_attributes,
-        agile=None
-    ):
+    def _set_agile(self, task_attributes, agile=None):
         """
         Method to set the agile attribute.
 
-        If the agile tag value isn't between the specified ones,
+        If the agile property value isn't between the specified ones,
         a `ValueError` will be raised.
 
         Arguments:
@@ -528,12 +512,14 @@ class TaskManager(TableManager):
 
         new_fulid = self.fulid.new(last_fulid)
 
-        fulid, task_attributes = self._set(project_id=project_id,
-                                           tags=tags,
-                                           agile=agile,
-                                           title=title,
-                                           state='open',
-                                           **kwargs)
+        fulid, task_attributes = self._set(
+            project_id=project_id,
+            tags=tags,
+            agile=agile,
+            title=title,
+            state='open',
+            **kwargs,
+        )
 
         self._add(
             task_attributes,
@@ -560,12 +546,14 @@ class TaskManager(TableManager):
             agile (str): Task agile state.
             **kwargs: (object) Other attributes (key: value).
         """
-        fulid, task_attributes = self._set(id,
-                                           project_id,
-                                           tags,
-                                           tags_rm,
-                                           agile,
-                                           **kwargs)
+        fulid, task_attributes = self._set(
+            id,
+            project_id,
+            tags,
+            tags_rm,
+            agile,
+            **kwargs
+        )
 
         self._update(
             fulid,

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -355,6 +355,28 @@ class TaskManager(TableManager):
 
         return fulid
 
+    def _set_project(
+        self,
+        task_attributes,
+        project_id=None
+    ):
+        """
+        Method to set the project attribute.
+
+        A new project will be created if it doesn't exist yet.
+
+        Arguments:
+            task_attributes (dict): Dictionary with the attributes of the task.
+            project_id (str): Project id.
+        """
+        if project_id is not None:
+            project = self.session.query(Project).get(project_id)
+            if project is None:
+                project = Project(id=project_id, description='')
+                self.session.add(project)
+                self.session.commit()
+            task_attributes['project'] = project
+
     def _set(
         self,
         id=None,
@@ -381,13 +403,7 @@ class TaskManager(TableManager):
         """
         task_attributes = {}
 
-        # Define Project
-        if project_id is not None:
-            project = self.session.query(Project).get(project_id)
-            if project is None:
-                project = Project(id=project_id, description='')
-                self.session.add(project)
-            task_attributes['project'] = project
+        self._set_project(task_attributes, project_id)
 
         # Define tags
         if id is not None:

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -364,37 +364,21 @@ class TaskManager(TableManager):
     def modify(
         self,
         id,
-        title=None,
-        agile=None,
-        body=None,
-        due=None,
-        estimate=None,
-        fun=None,
-        state=None,
-        priority=None,
         project_id=None,
         tags=[],
         tags_rm=[],
-        value=None,
-        willpower=None,
+        agile=None,
+        **kwargs
     ):
         """
         Use parent method to modify an existing task
 
         Arguments:
-            agile (str): Task agile state.
-            title (str): Title of the task.
-            body (str): Description of the task.
-            estimate (float): Estimate size of the task.
-            fun (int): Fun size of the task.
-            state (str): State of the task once it's closed
-            priority (int): Task priority.
             project_id (str): Project id.
             tags (list): List of tag ids.
             tags_rm (list): List of tag ids to remove.
-            title (str): Title of the task.
-            value (int): Objective/Bussiness value of the task.
-            willpower (int): Willpower consumption of the task.
+            agile (str): Task agile state.
+            **kwargs: (object) Other attributes (key: value).
         """
         if len(id) < 10:
             open_tasks = self.session.query(Task).filter_by(state='open')
@@ -444,24 +428,9 @@ class TaskManager(TableManager):
 
         if agile is not None:
             task_attributes['agile'] = agile
-        if body is not None:
-            task_attributes['body'] = body
-        if due is not None:
-            task_attributes['due'] = due
-        if title is not None:
-            task_attributes['title'] = title
-        if estimate is not None:
-            task_attributes['estimate'] = estimate
-        if fun is not None:
-            task_attributes['fun'] = fun
-        if state is not None:
-            task_attributes['state'] = state
-        if priority is not None:
-            task_attributes['priority'] = priority
-        if value is not None:
-            task_attributes['value'] = value
-        if willpower is not None:
-            task_attributes['willpower'] = willpower
+
+        for key, value in kwargs.items():
+            task_attributes[key] = value
 
         self._update(
             id,

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -528,11 +528,9 @@ class TaskManager(TableManager):
 
         new_fulid = self.fulid.new(last_fulid)
 
-        fulid, task_attributes = self._set(None,
-                                           project_id,
-                                           tags,
-                                           None,
-                                           agile,
+        fulid, task_attributes = self._set(project_id=project_id,
+                                           tags=tags,
+                                           agile=agile,
                                            title=title,
                                            state='open',
                                            **kwargs)

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -434,25 +434,18 @@ class TaskManager(TableManager):
         title,
         project_id=None,
         tags=[],
-        tags_rm=[],
         agile=None,
         **kwargs
     ):
         """
-        Use parent method to create a new task
+        Use parent method to create a new task.
 
         Arguments:
-            agile (str): Task agile state.
             title (str): Title of the task.
-            body (str): Description of the task.
-            estimate (float): Estimate size of the task.
-            fun (int): Fun size of the task.
-            priority (int): Task priority.
             project_id (str): Project id.
             tags (list): List of tag ids.
-            title (str): Title of the task.
-            value (int): Objective/Bussiness value of the task.
-            willpower (int): Willpower consumption of the task.
+            agile (str): Task agile state.
+            **kwargs: (object) Other attributes (key: value).
         """
 
         # Define ID
@@ -490,7 +483,7 @@ class TaskManager(TableManager):
         **kwargs
     ):
         """
-        Use parent method to modify an existing task
+        Use parent method to modify an existing task.
 
         Arguments:
             project_id (str): Project id.

--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -456,6 +456,7 @@ class TaskManager(TableManager):
             fulid (str): fulid that matches the sulid.
             task_attributes (dict): Dictionary with the attributes of the task.
         """
+        fulid = None
         task_attributes = {}
 
         self._set_project(task_attributes, project_id)
@@ -472,9 +473,6 @@ class TaskManager(TableManager):
                     tag = Tag(id=tag_id, description='')
                     self.session.add(tag)
                 task_attributes['tags'].remove(tag)
-        else:
-            fulid = None
-            task_attributes['tags'] = []
 
         self._set_tags(task_attributes, tags)
         self._set_agile(task_attributes, agile)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,31 @@ class TestArgparse:
         assert parsed.subcommand == arguments[0]
         assert parsed.add_argument == arguments[1:3]
 
+    def test_can_specify_modify_subcommand(self):
+        arguments = [
+            'modify',
+            self.fake.word(),
+            self.fake.sentence(),
+        ]
+        parsed = self.parser.parse_args(arguments)
+        assert parsed.subcommand == arguments[0]
+        assert parsed.ulid == arguments[1]
+        assert parsed.modify_argument == [arguments[2]]
+
+    def test_can_specify_project_in_modify_subcommand(self):
+        description = self.fake.sentence()
+        project_id = self.fake.word()
+        arguments = [
+            'modify',
+            self.fake.word(),
+            description,
+            'pro:{}'.format(project_id),
+        ]
+        parsed = self.parser.parse_args(arguments)
+        assert parsed.subcommand == arguments[0]
+        assert parsed.ulid == arguments[1]
+        assert parsed.modify_argument == arguments[2:4]
+
     def test_can_specify_done_subcommand(self):
         arguments = [
             'done',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,7 @@ class TestArgparse:
 
     def test_can_specify_modify_subcommand(self):
         arguments = [
-            'modify',
+            'mod',
             self.fake.word(),
             self.fake.sentence(),
         ]
@@ -55,7 +55,7 @@ class TestArgparse:
         description = self.fake.sentence()
         project_id = self.fake.word()
         arguments = [
-            'modify',
+            'mod',
             self.fake.word(),
             description,
             'pro:{}'.format(project_id),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -255,3 +255,23 @@ class TestMain:
             columns=self.config.get('report.tags.columns').split(', '),
             labels=self.config.get('report.tags.labels').split(', ')
         )
+
+    def test_modify_subcomand_modifies_task(self):
+        arguments = [
+            'mod',
+            ulid.new().str,
+            'pro:test',
+        ]
+        self.parser_args.subcommand = arguments[0]
+        self.parser_args.ulid = arguments[1]
+        self.parser_args.modify_argument = arguments[2]
+        self.tm.return_value._parse_arguments.return_value = {
+            'project': 'test',
+        }
+
+        main()
+
+        self.tm.return_value.modify.assert_called_once_with(
+            arguments[1],
+            project='test',
+        )

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -84,8 +84,6 @@ class ManagerBaseTest:
         with pytest.raises(ValueError):
             self.manager._update(fake_element_id)
 
-        self.session.commit()
-
 
 @pytest.mark.usefixtures('base_setup')
 class TestTaskManager(ManagerBaseTest):
@@ -432,7 +430,7 @@ class TestTaskManager(ManagerBaseTest):
         tag1 = TagFactory.create()
         tag2 = TagFactory.create()
         tag3 = TagFactory.create()
-        task_attributes = {'tags': [tag1.id, tag2.id, tag3.id]}
+        task_attributes = {'tags': [tag1, tag2, tag3]}
 
         with pytest.raises(ValueError):
             self.manager._rm_tags(task_attributes, ['tag4', 'tag5'])

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -418,6 +418,25 @@ class TestTaskManager(ManagerBaseTest):
 
         assert task_attributes['tags'][0].id == 'non_existent'
 
+    def test_rm_tags_existent(self):
+        tag1 = TagFactory.create()
+        tag2 = TagFactory.create()
+        tag3 = TagFactory.create()
+        task_attributes = {'tags': [tag1, tag2, tag3]}
+
+        self.manager._rm_tags(task_attributes, [tag1.id, tag2.id])
+
+        assert task_attributes['tags'] == [tag3]
+
+    def test_rm_tags_non_existent(self):
+        tag1 = TagFactory.create()
+        tag2 = TagFactory.create()
+        tag3 = TagFactory.create()
+        task_attributes = {'tags': [tag1.id, tag2.id, tag3.id]}
+
+        with pytest.raises(ValueError):
+            self.manager._rm_tags(task_attributes, ['tag4', 'tag5'])
+
     def test_set_agile_valid(self):
         agile = 'todo'
         task_attributes = {}

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -84,6 +84,7 @@ class ManagerBaseTest:
         with pytest.raises(ValueError):
             self.manager._update(fake_element_id)
 
+        self.session.commit()
 
 @pytest.mark.usefixtures('base_setup')
 class TestTaskManager(ManagerBaseTest):
@@ -546,6 +547,19 @@ class TestTaskManager(ManagerBaseTest):
 
         self.manager.modify(
             fulid().fulid_to_sulid(task.id, [task.id]),
+            non_existent=non_existent_attribute_value
+        )
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.non_existent is non_existent_attribute_value
+
+    def test_modify_task_modifies_arbitrary_attribute_any_state(self):
+        task = self.factory.create()
+        non_existent_attribute_value = self.fake.word()
+
+        self.manager.modify(
+            task.id,
             non_existent=non_existent_attribute_value
         )
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -151,6 +151,21 @@ class TestTaskManager(ManagerBaseTest):
         assert attributes['title'] == title
         assert attributes['tags'] == tags
 
+    def test_parse_arguments_extracts_tags_to_remove(self):
+        title = self.fake.sentence()
+        tags = [self.fake.word(), self.fake.word()]
+
+        add_arguments = [
+            title,
+            '-{}'.format(tags[0]),
+            '-{}'.format(tags[1]),
+        ]
+
+        attributes = self.manager._parse_arguments(add_arguments)
+
+        assert attributes['title'] == title
+        assert attributes['tags_rm'] == tags
+
     def test_parse_arguments_extracts_priority_in_short_representation(self):
         title = self.fake.sentence()
         priority = self.fake.random_number()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -66,6 +66,23 @@ class ManagerBaseTest:
         with pytest.raises(ValueError):
             self.manager._get('unexistent_property')
 
+    def test_update_table_element_method_exists(self):
+        assert '_update' in dir(self.manager)
+
+    def test_update_element(self):
+        element = self.factory.create()
+
+        attribute_value = self.fake.sentence()
+        object_values = {'arbitrary_key': attribute_value}
+        self.manager._update(element.id, object_values)
+
+        assert element.arbitrary_key == attribute_value
+
+    def test_update_raises_valueerror_if_element_doesnt_exist(self):
+        fake_element_id = self.fake.word()
+
+        with pytest.raises(ValueError):
+            self.manager._update(fake_element_id)
 
 @pytest.mark.usefixtures('base_setup')
 class TestTaskManager(ManagerBaseTest):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -418,6 +418,21 @@ class TestTaskManager(ManagerBaseTest):
 
         assert task_attributes['tags'][0].id == 'non_existent'
 
+    def test_set_agile_valid(self):
+        agile = 'todo'
+        task_attributes = {}
+
+        self.manager._set_agile(task_attributes, agile)
+
+        assert task_attributes['agile'] == agile
+
+    def test_set_agile_unvalid(self):
+        agile = self.fake.word()
+        task_attributes = {}
+
+        with pytest.raises(ValueError):
+            self.manager._set_agile(task_attributes, agile)
+
     def test_add_task(self):
         title = self.fake.sentence()
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -86,6 +86,7 @@ class ManagerBaseTest:
 
         self.session.commit()
 
+
 @pytest.mark.usefixtures('base_setup')
 class TestTaskManager(ManagerBaseTest):
     """
@@ -368,6 +369,23 @@ class TestTaskManager(ManagerBaseTest):
         attributes = self.manager._parse_arguments(add_arguments)
 
         assert attributes['due'] == dateMock.return_value.convert.return_value
+
+    def test_get_fulid_from_sulid(self):
+        task = self.factory.create(state='open')
+        sulid = self.manager.fulid.fulid_to_sulid(task.id, [task.id])
+
+        assert task.id == self.manager._get_fulid(sulid)
+
+    def test_get_fulid_from_fulid(self):
+        task = self.factory.create(state='open')
+
+        assert task.id == self.manager._get_fulid(task.id)
+
+    def test_get_fulid_non_existent_task(self):
+        non_existent_id = self.fake.word()
+
+        with pytest.raises(KeyError):
+            self.manager._get_fulid(non_existent_id)
 
     def test_add_task(self):
         title = self.fake.sentence()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -507,6 +507,177 @@ class TestTaskManager(ManagerBaseTest):
         generated_task = self.session.query(Task).one()
         assert generated_task.due == due
 
+    def test_modify_task_modifies_project(self):
+        old_project = ProjectFactory.create()
+        new_project = ProjectFactory.create()
+        task = self.factory.create(state='open')
+        task.project = old_project
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            project_id=new_project.id
+        )
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.project is new_project
+
+    def test_modify_task_generates_project_if_doesnt_exist(self):
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            project_id='non_existent')
+
+        modified_task = self.session.query(Task).get(task.id)
+        project = self.session.query(Project).get('non_existent')
+
+        assert modified_task.project is project
+        assert isinstance(project, Project)
+
+    def test_modify_task_adds_tags(self):
+        tag_1 = TagFactory.create()
+        tag_2 = TagFactory.create()
+        task = self.factory.create(state='open')
+        task.tags = [tag_1]
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            tags=[tag_2.id])
+
+        modified_task = self.session.query(Task).get(task.id)
+        assert modified_task.tags == [tag_1, tag_2]
+
+    def test_modify_task_removes_tags(self):
+        tag = TagFactory.create()
+        task = self.factory.create(state='open')
+        task.tags = [tag]
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            tags_rm=[tag.id])
+
+        modified_task = self.session.query(Task).get(task.id)
+        assert modified_task.tags == []
+
+    def test_modify_task_generates_tag_if_doesnt_exist(self):
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            tags=['non_existent'])
+
+        modified_task = self.session.query(Task).get(task.id)
+        tag = self.session.query(Tag).get('non_existent')
+
+        assert modified_task.tags == [tag]
+        assert isinstance(tag, Tag)
+
+    def test_modify_task_modifies_priority(self):
+        priority = self.fake.random_number()
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            priority=priority)
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.priority == priority
+
+    def test_modify_task_modifies_value(self):
+        value = self.fake.random_number()
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            value=value)
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.value == value
+
+    def test_modify_task_modifies_willpower(self):
+        willpower = self.fake.random_number()
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            willpower=willpower)
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.willpower == willpower
+
+    def test_modify_task_modifies_fun(self):
+        fun = self.fake.random_number()
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            fun=fun)
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.fun == fun
+
+    def test_modify_task_modifies_estimate(self):
+        estimate = self.fake.random_number()
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            estimate=estimate)
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.estimate == estimate
+
+    def test_modify_task_modifies_body(self):
+        body = self.fake.sentence()
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            body=body)
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.body == body
+
+    def test_raise_error_if_add_task_modifies_unvalid_agile_state(self):
+        task = self.factory.create(state='open')
+        agile = self.fake.word()
+
+        with pytest.raises(ValueError):
+            self.manager.modify(
+                fulid().fulid_to_sulid(task.id, [task.id]),
+                agile=agile)
+
+    def test_add_task_modifies_agile(self):
+        agile = 'todo'
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            agile=agile)
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.agile == agile
+
+    def test_add_task_modifies_due(self):
+        due = self.fake.date_time()
+        task = self.factory.create(state='open')
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            due=due)
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.due == due
+
     def test_delete_task_by_sulid(self):
         task = self.factory.create(state='open')
         closed = self.fake.date_time()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -522,6 +522,19 @@ class TestTaskManager(ManagerBaseTest):
         generated_task = self.session.query(Task).one()
         assert generated_task.due == due
 
+    def test_modify_task_modifies_arbitrary_attribute(self):
+        task = self.factory.create(state='open')
+        non_existent_attribute_value = self.fake.word()
+
+        self.manager.modify(
+            fulid().fulid_to_sulid(task.id, [task.id]),
+            non_existent=non_existent_attribute_value
+        )
+
+        modified_task = self.session.query(Task).get(task.id)
+
+        assert modified_task.non_existent is non_existent_attribute_value
+
     def test_modify_task_modifies_project(self):
         old_project = ProjectFactory.create()
         new_project = ProjectFactory.create()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -387,6 +387,21 @@ class TestTaskManager(ManagerBaseTest):
         with pytest.raises(KeyError):
             self.manager._get_fulid(non_existent_id)
 
+    def test_set_project_existent(self):
+        project = ProjectFactory.create()
+        task_attributes = {}
+
+        self.manager._set_project(task_attributes, project.id)
+
+        assert task_attributes['project'] == project
+
+    def test_set_project_non_existent(self):
+        task_attributes = {}
+
+        self.manager._set_project(task_attributes, 'non_existent')
+
+        assert task_attributes['project'].id == 'non_existent'
+
     def test_add_task(self):
         title = self.fake.sentence()
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -402,6 +402,22 @@ class TestTaskManager(ManagerBaseTest):
 
         assert task_attributes['project'].id == 'non_existent'
 
+    def test_set_tags_existent(self):
+        tag1 = TagFactory.create()
+        tag2 = TagFactory.create()
+        task_attributes = {}
+
+        self.manager._set_tags(task_attributes, [tag1.id, tag2.id])
+
+        assert task_attributes['tags'] == [tag1, tag2]
+
+    def test_set_tags_non_existent(self):
+        task_attributes = {}
+
+        self.manager._set_tags(task_attributes, ['non_existent'])
+
+        assert task_attributes['tags'][0].id == 'non_existent'
+
     def test_add_task(self):
         title = self.fake.sentence()
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -452,6 +452,50 @@ class TestTaskManager(ManagerBaseTest):
         with pytest.raises(ValueError):
             self.manager._set_agile(task_attributes, agile)
 
+    def test_set_existent_task(self):
+        task = self.factory.create()
+        project = ProjectFactory.create()
+        tag = TagFactory.create()
+        agile = 'todo'
+        arbitrary_attribute_value = self.fake.word()
+
+        fulid, task_attributes = self.manager._set(
+            task.id,
+            project.id,
+            [tag.id],
+            [],
+            agile,
+            arbitrary_attribute=arbitrary_attribute_value
+        )
+
+        assert fulid == task.id
+        assert task_attributes['project'] == project
+        assert task_attributes['tags'] == [tag]
+        assert task_attributes['agile'] == agile
+        assert task_attributes['arbitrary_attribute'] == \
+            arbitrary_attribute_value
+
+    def test_set_non_existent_task(self):
+        project = ProjectFactory.create()
+        tag = TagFactory.create()
+        agile = 'todo'
+        arbitrary_attribute_value = self.fake.word()
+
+        fulid, task_attributes = self.manager._set(
+            None,
+            project.id,
+            [tag.id],
+            [],
+            agile,
+            arbitrary_attribute=arbitrary_attribute_value
+        )
+
+        assert task_attributes['project'] == project
+        assert task_attributes['tags'] == [tag]
+        assert task_attributes['agile'] == agile
+        assert task_attributes['arbitrary_attribute'] == \
+            arbitrary_attribute_value
+
     def test_add_task(self):
         title = self.fake.sentence()
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -84,6 +84,7 @@ class ManagerBaseTest:
         with pytest.raises(ValueError):
             self.manager._update(fake_element_id)
 
+
 @pytest.mark.usefixtures('base_setup')
 class TestTaskManager(ManagerBaseTest):
     """


### PR DESCRIPTION
Implemented `pydo modify` that allows to modify an exisitng task's attributes.

Supports appending tags (+) or removing them (-). Doesn't support removing attributes, which would be nice (for example removing a due date). The implementation is mostly based on the add command. Added tests for the implemented functions.

Solves part of #8. A general `update` function was implemented so it might be useful for modifying other resources (projects, tags...).

**Issues**: One of the new tests generates a warning, I need help with this.

Total time spent on this PR so far: 5h.