### PR TITLE
Fix mod empty title

### DIFF
--- a/pydo/manager.py
+++ b/pydo/manager.py
@@ -341,7 +341,11 @@ class TaskManager(TableManager):
             else:
                 attributes[attribute_id] = attribute_value
 
-        attributes['title'] = ' '.join(attributes['title'])
+        if len(attributes['title']) > 0:
+            attributes['title'] = ' '.join(attributes['title'])
+        else:
+            del attributes['title']
+
         return attributes
 
     def _get_fulid(self, id):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -128,6 +128,11 @@ class TestTaskManager(ManagerBaseTest):
 
         assert attributes['title'] == title
 
+    def test_parse_arguments_allows_empty_title(self):
+        attributes = self.manager._parse_arguments('')
+
+        assert 'title' not in attributes
+
     def test_parse_arguments_extracts_project_in_short_representation(self):
         title = self.fake.sentence()
         project = self.fake.word()


### PR DESCRIPTION
Title was set to an empty string in the parser if no title was passed in https://github.com/lyz-code/pydo/blob/b06e8880b106c0280804a29fa20803cd04de7148/pydo/manager.py#L344
because title is passed as `[]` by default.

Now the `title` key is set to `None` if no title is passed, so it won't be updated in the database. Tasks must have a title.

Fixes #63.